### PR TITLE
Tweak to workflow so that it works with projects that have changed the name.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           echo $(pwd)
           cd NeoDK/firmware
-          SEGGER=~/work/NeoDK/NeoDK/SEGGER_RTT_V792/RTT/ STM32CUBE_G0=~/work/NeoDK/NeoDK/STM32CubeG0 GNU_INSTALL_ROOT=$(dirname $(which arm-none-eabi-gcc))/ make
+          SEGGER="${GITHUB_WORKSPACE}/SEGGER_RTT_V792/RTT/" STM32CUBE_G0="${GITHUB_WORKSPACE}"/STM32CubeG0 GNU_INSTALL_ROOT=$(dirname $(which arm-none-eabi-gcc))/ make
           
       - name: Upload firmware artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Uses the workflow path environment variable instead of hardcoding ~/work/NeoDK/NeoDK.
This fixes an invalid-path issue if a cloned repository uses a different name.